### PR TITLE
fix peer_regexp bug

### DIFF
--- a/etcd-aws-cluster
+++ b/etcd-aws-cluster
@@ -75,7 +75,7 @@ if [[ $etcd_existing_peer_urls && $etcd_existing_peer_names != *"$ec2_instance_i
     echo "joining existing cluster"
 
     # eject bad members from cluster
-    peer_regexp=$(echo "$etcd_peer_urls" | sed 's/^.*http:\/\/\([0-9.]*\):[0-9]*.*$/contains(\\"\1\\")/' | xargs | sed 's/  */ or /g')
+    peer_regexp=$(echo "$etcd_peer_urls" | sed 's/^.*http:\/\/\([0-9.]*\):[0-9]*.*$/contains(\\"\/\/\1:\\")/' | xargs | sed 's/  */ or /g')
     if [[ ! $peer_regexp ]]; then
         echo "$pkg: failed to create peer regular expression"
         exit 6


### PR DESCRIPTION
The peer_regexp used to identify bad_peer is not restrict enough and misses bad peers when the bad instance's IP contains the substring of the regexp. Example:

Healthy peers:
10.0.2.15
10.0.2.36
10.0.2.77

Unhealthy peer - gone due to autoscaling:
10.0.2.150

10.0.2.150 will not be  identified as bad peer  because it contains 10.0.2.15 substring. It can cause the cluster lose majority if not removed. 

Proposed the change: instead of using contains("10.0.2.15") or contains(..) regexp condition, use contains("//10.0.2.15:")
