### PR TITLE
Fixed docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Workflow
 Usage
 -----
 
-```docker run -v /etc/sysconfig/:/etc/sysconfig/ MonsantoCo/etcd-aws-cluster```
+```docker run -v /etc/sysconfig/:/etc/sysconfig/ monsantoco/etcd-aws-cluster```
 
 Demo
 ----


### PR DESCRIPTION
With Docker 1.10, at least:

invalid reference format: repository name must be lowercase
