### PR TITLE
Change the base Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM gliderlabs/alpine:3.4
+FROM python:2.7-alpine
 
 RUN apk --update add \
-      python \
-      py-pip \
       jq \
       curl \
       wget \


### PR DESCRIPTION
Use the official python:2.7-alpine image for the same environment but
a slightly better build (faster to build the image, clearer what version
of Python's in there).
