### PR TITLE
Use etcd_peer_scheme for peerURL when joining existing cluster

### DIFF
--- a/etcd-aws-cluster
+++ b/etcd-aws-cluster
@@ -133,7 +133,8 @@ if [[ $etcd_existing_peer_urls && $etcd_existing_peer_names != *"$ec2_instance_i
 
     # If we're not a proxy we add ourselves as a member to the cluster
     if [[ ! $PROXY_ASG ]]; then
-        etcd_initial_cluster=$(curl $ETCD_CURLOPTS -s -f "$etcd_good_member_url/v2/members" | jq --raw-output '.[] | map(.name + "=" + .peerURLs[0]) | .[]' | xargs | sed 's/  */,/g')$(echo ",$ec2_instance_id=${etcd_peer_scheme}://${ec2_instance_ip}:$server_port")
+        peer_url="$etcd_peer_scheme://$ec2_instance_ip:$server_port"
+        etcd_initial_cluster=$(curl $ETCD_CURLOPTS -s -f "$etcd_good_member_url/v2/members" | jq --raw-output '.[] | map(.name + "=" + .peerURLs[0]) | .[]' | xargs | sed 's/  */,/g')$(echo ",$ec2_instance_id=$peer_url")
         echo "etcd_initial_cluster=$etcd_initial_cluster"
         if [[ ! $etcd_initial_cluster ]]; then
             echo "$pkg: docker command to get etcd peers failed"
@@ -144,15 +145,15 @@ if [[ $etcd_existing_peer_urls && $etcd_existing_peer_names != *"$ec2_instance_i
         status=0
         retry=1
         until [[ $status = $add_ok || $status = $already_added || $retry = $retry_times ]]; do
-            status=$(curl $ETCD_CURLOPTS -f -s -w %{http_code} -o /dev/null -XPOST "$etcd_good_member_url/v2/members" -H "Content-Type: application/json" -d "{\"peerURLs\": [\"http://$ec2_instance_ip:$server_port\"], \"name\": \"$ec2_instance_id\"}")
-            echo "$pkg: adding instance ID $ec2_instance_id with IP $ec2_instance_ip, retry $((retry++)), return code $status."
+            status=$(curl $ETCD_CURLOPTS -f -s -w %{http_code} -o /dev/null -XPOST "$etcd_good_member_url/v2/members" -H "Content-Type: application/json" -d "{\"peerURLs\": [\"$peer_url\"], \"name\": \"$ec2_instance_id\"}")
+            echo "$pkg: adding instance ID $ec2_instance_id with peer URL $peer_url, retry $((retry++)), return code $status."
             sleep $wait_time
         done
         if [[ $status != $add_ok && $status != $already_added ]]; then
-            echo "$pkg: unable to add $ec2_instance_ip to the cluster: return code $status."
+            echo "$pkg: unable to add $peer_url to the cluster: return code $status."
             exit 9
         else
-            echo "$pkg: added $ec2_instance_ip to existing cluster, return code $status"
+            echo "$pkg: added $peer_url to existing cluster, return code $status"
         fi
     # If we are a proxy we just want the list for the actual cluster
     else


### PR DESCRIPTION
Similar to #29, 314e944 seems to have removed using `$etcd_peer_scheme` from the peer URL when a node tries to join an existing cluster. This causes nodes joining the cluster to fail if etcd_peer_scheme=https because of a peerURL mismatch -- the cluster advertises https://$new_node_ip:$port and the node is trying to join with http://$new_node_ip:$port.